### PR TITLE
feat: AuthModelContext

### DIFF
--- a/src/ads/pages/CardCatalogBig/CommentWindow/CommentWindow.tsx
+++ b/src/ads/pages/CardCatalogBig/CommentWindow/CommentWindow.tsx
@@ -79,6 +79,7 @@ export default function CommentWindow({ onClose }: Props) {
     methods.setValue("rating", rating);
   };
 
+
   return (
     <section className={styles.section}>
       {message && (

--- a/src/app/layouts/RootLayout/RootLayout .tsx
+++ b/src/app/layouts/RootLayout/RootLayout .tsx
@@ -1,0 +1,16 @@
+import { Outlet } from "react-router-dom";
+import AuthModal from "../../../user/components/userAuthModal/AuthModal";
+import { useAuthModal } from "../../../user/providers/AuthModalContext";
+
+const RootLayout = () => {
+   const {isOpen} = useAuthModal();
+
+  return (
+    <>
+      <Outlet />
+      {isOpen && <AuthModal/>}
+    </>
+  );
+};
+
+export default RootLayout;

--- a/src/app/layouts/RootModal/RootModal.tsx
+++ b/src/app/layouts/RootModal/RootModal.tsx
@@ -23,7 +23,7 @@ export const RootModal = ({
       className={`${styles.modal} ${backdropFilter && styles.modal__filter}`}
       onClick={onClose}
     >
-      {children}
+      <div onClick={(e) => e.stopPropagation()}>{children}</div>
     </div>,
     modalElement
   );

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -30,136 +30,142 @@ import { UserFavorites } from "../user/pages/UserFavorites/UserFavorites";
 import { UserAds } from "../user/pages/UserAds/UserAds";
 import PasswordChange from "../user/pages/passwordChange/passwordChange";
 import { SearchProvider } from "./layouts/SearchProvider/SearchProvider";
+import RootLayout from "./layouts/RootLayout/RootLayout ";
 
 export const router = createBrowserRouter(
   [
     {
-      element: <ProtectedRoute />,
-      loader: loaderProtectedRoute, // Wrap ModerationPage in ProtectedRoute
-      children: [
-        // {
-        //   // Отдельная группа для модерации
-        //   element: <ModeratorProtectedRoute />,
-        //   children: [
-        {
-          path: paths.moderation,
-          element: <ModerationPage />,
-        },
-        {
-          path: paths.profile,
-          element: <UserLK />,
-        },
-        {
-          path: paths.settings,
-          element: <SettingsUser />,
-        },
-        {
-          path: paths.user_profile_edit,
-          element: <UserProfileEdit />,
-        },
-        {
-          path: paths.passwordChange,
-          element: <PasswordChange />,
-        },
-      ],
-    },
-    {
-      element: (
-        <SearchProvider>
-          <MainLayout />
-        </SearchProvider>
-      ),
-      path: paths.index,
+      element: <RootLayout />,
       children: [
         {
-          path: paths.chat,
-          element: <ChatPage />,
-        },
-        {
-          path: paths.catalog,
-          element: <Catalog />,
-          loader: LoaderInitPage,
-        },
-        {
-          path: paths.catalogService,
-          element: <CardCatalogBig />, // убрать
-          loader: (params) => loaderAdsByCatalogId(params),
-        },
-        {
-          path: paths.adPage,
-          element: <CardCatalogBig />, // убрать
-          loader: (params) => loaderAdsByCatalogId(params),
-        },
-        {
-          path: paths.servicePage,
-          element: <CardCatalogBig />, // убрать
-          loader: (params) => loaderAdsByCatalogId(params),
-        },
-
-        {
-          path: paths.createAds,
-          element: <CreateAds />,
-          loader: () => loaderCatagories(),
+          element: <ProtectedRoute />,
+          loader: loaderProtectedRoute, // Wrap ModerationPage in ProtectedRoute
           children: [
+            // {
+            //   // Отдельная группа для модерации
+            //   element: <ModeratorProtectedRoute />,
+            //   children: [
             {
-              path: paths.createAds,
-              element: <MainFormAds />,
-              loader: () => loaderCatagories(),
+              path: paths.moderation,
+              element: <ModerationPage />,
+            },
+            {
+              path: paths.profile,
+              element: <UserLK />,
+            },
+            {
+              path: paths.settings,
+              element: <SettingsUser />,
+            },
+            {
+              path: paths.user_profile_edit,
+              element: <UserProfileEdit />,
+            },
+            {
+              path: paths.passwordChange,
+              element: <PasswordChange />,
             },
           ],
         },
-
         {
-          path: paths.typeCatalog,
-          element: <TypeCatalog />,
-          loader: loaderTypesCatalog,
-        },
-        {
+          element: (
+            <SearchProvider>
+              <MainLayout />
+            </SearchProvider>
+          ),
           path: paths.index,
-          element: <MainCatalog />,
-          loader: () => loaderCatagories(),
+          children: [
+            {
+              path: paths.chat,
+              element: <ChatPage />,
+            },
+            {
+              path: paths.catalog,
+              element: <Catalog />,
+              loader: LoaderInitPage,
+            },
+            {
+              path: paths.catalogService,
+              element: <CardCatalogBig />, // убрать
+              loader: (params) => loaderAdsByCatalogId(params),
+            },
+            {
+              path: paths.adPage,
+              element: <CardCatalogBig />, // убрать
+              loader: (params) => loaderAdsByCatalogId(params),
+            },
+            {
+              path: paths.servicePage,
+              element: <CardCatalogBig />, // убрать
+              loader: (params) => loaderAdsByCatalogId(params),
+            },
+
+            {
+              path: paths.createAds,
+              element: <CreateAds />,
+              loader: () => loaderCatagories(),
+              children: [
+                {
+                  path: paths.createAds,
+                  element: <MainFormAds />,
+                  loader: () => loaderCatagories(),
+                },
+              ],
+            },
+
+            {
+              path: paths.typeCatalog,
+              element: <TypeCatalog />,
+              loader: loaderTypesCatalog,
+            },
+            {
+              path: paths.index,
+              element: <MainCatalog />,
+              loader: () => loaderCatagories(),
+            },
+            {
+              path: paths.favorites,
+              element: <UserFavorites />,
+            },
+            {
+              path: paths.myAds,
+              element: <UserAds />,
+            },
+          ],
+        },
+        // ],
+
+        //   ],
+        // },
+        {
+          path: paths.auth,
+          element: <Login />,
         },
         {
-          path: paths.favorites,
-          element: <UserFavorites />,
+          path: paths.forgetPassword,
+          element: <NewPassword />,
         },
         {
-          path: paths.myAds,
-          element: <UserAds />,
+          path: paths.passwordRecovery,
+          element: <PasswordRecovery />,
+        },
+        {
+          path: paths.register,
+          element: <Registr />,
+        },
+        {
+          path: paths.confirmEmail,
+          element: <ConfirmEmail />,
+        },
+        {
+          path: paths.policy,
+          element: <PolicyPage />,
+        },
+        {
+          path: paths.registryActivate,
+          element: <RegisterActivatePage />,
         },
       ],
-    },
-    // ],
-
-    //   ],
-    // },
-    {
-      path: paths.auth,
-      element: <Login />,
-    },
-    {
-      path: paths.forgetPassword,
-      element: <NewPassword />,
-    },
-    {
-      path: paths.passwordRecovery,
-      element: <PasswordRecovery />,
-    },
-    {
-      path: paths.register,
-      element: <Registr />,
-    },
-    {
-      path: paths.confirmEmail,
-      element: <ConfirmEmail />,
-    },
-    {
-      path: paths.policy,
-      element: <PolicyPage />,
-    },
-    {
-      path: paths.registryActivate,
-      element: <RegisterActivatePage />,
     },
   ],
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
-import { router } from './app/router.tsx';
-import { Provider } from 'react-redux';
-import { store } from './store/store.ts';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+import { AuthModalProvider } from "./user/providers/AuthModalContext.tsx";
+import { router } from "./app/router.tsx";
+import { Provider } from "react-redux";
+import { store } from "./store/store.ts";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <Provider store={store}>
-      <React.Suspense fallback={<div>Loading...</div>}>
-        <RouterProvider router={router} />
-      </React.Suspense>
+      <AuthModalProvider>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <RouterProvider router={router}>
+
+          </RouterProvider>
+        </React.Suspense>{" "}
+      </AuthModalProvider>
     </Provider>
   </React.StrictMode>
 );

--- a/src/user/components/authorCardCatalog/CardCatalogAuthor.tsx
+++ b/src/user/components/authorCardCatalog/CardCatalogAuthor.tsx
@@ -4,6 +4,7 @@ import star from "../../../assets/icon/Star.svg";
 import { ServiceInfo } from "../../../common/model/ads";
 import { useNavigate } from "react-router-dom";
 import { useAppSelector } from "../../../store/store";
+import { useAuthModal } from "../../providers/AuthModalContext";
 
 interface Props {
   card: ServiceInfo;
@@ -11,12 +12,13 @@ interface Props {
 
 export default function CardCatalogAuthor({ card }: Props) {
   const user = useAppSelector((state) => state.auth.user);
+  const { openLogin } = useAuthModal();
   const navigate = useNavigate();
   const handleGoAds = () => {
     if (user) {
       navigate(`/chat/${card.type}/${card.id}/${user.id}`);
     } else {
-      console.warn("Вы не авторизованы");
+      openLogin();
     }
   };
 
@@ -42,9 +44,7 @@ export default function CardCatalogAuthor({ card }: Props) {
           <img src={star} alt="звезда" className={style.arrowBack} />
         </div>
 
-        <div >
-          {card.comments_quantity} отзывов
-        </div>
+        <div>{card.comments_quantity} отзывов</div>
       </div>
 
       <div className={style.catalog__buttons}>

--- a/src/user/components/header/Header.tsx
+++ b/src/user/components/header/Header.tsx
@@ -10,15 +10,17 @@ import styles from "./header.module.scss";
 import { paths } from "../../../app/paths";
 import userIcon from "../../../assets/icon/menu/user.svg";
 import { useSearch } from "../../../app/layouts/SearchProvider/SearchProvider";
+import { useAuthModal } from "../../providers/AuthModalContext";
 
 export default function Header() {
   const navigate = useNavigate();
   const [trigger, { data: user, isLoading }] = useLazyCheckAuthQuery();
   const [searchString, handleSearchItems] = useSearch();
+  const { openLogin } = useAuthModal();
 
   const createAds = () => {
     if (!user) {
-      navigate(paths.auth);
+      openLogin();
       return;
     }
     navigate(paths.createAds);
@@ -53,7 +55,9 @@ export default function Header() {
         ) : (
           <button
             className={styles.authButton}
-            onClick={() => navigate(paths.auth)}
+            onClick={() => {
+              openLogin();
+            }}
           >
             Вход и регистрация
           </button>

--- a/src/user/components/userAuthModal/AuthModal.tsx
+++ b/src/user/components/userAuthModal/AuthModal.tsx
@@ -1,0 +1,17 @@
+import { RootModal } from "../../../app/layouts/RootModal/RootModal";
+import LogIn from "../../pages/logIn/logIn";
+import Registr from "../../pages/singin/SignIn";
+import { useAuthModal } from "../../providers/AuthModalContext";
+
+const AuthModal = () => {
+  const { type, closeAuthModal } = useAuthModal();
+
+  return (
+    <RootModal onClose={closeAuthModal}>
+      {type === "login" && <LogIn />}
+      {type === "register" && <Registr />}
+    </RootModal>
+  );
+};
+
+export default AuthModal;

--- a/src/user/pages/logIn/LogIn.module.scss
+++ b/src/user/pages/logIn/LogIn.module.scss
@@ -28,7 +28,7 @@
     justify-content: space-between;
   }
 
-  &_linkRegistr {
+  &_buttonRegistr {
     margin: 55px 0;
     padding: 0;
     height: 56px;
@@ -36,10 +36,11 @@
     justify-content: center;
     align-items: center;
 
-    &_linkText {
+    &_buttonText {
       margin: 32px 0 0 0;
       padding: 0;
       color: rgb(118, 160, 94);
+      border: none;
       font-family: "Inter", Arial, Helvetica, sans-serif;
       font-size: 19px;
       font-weight: 600;
@@ -47,22 +48,24 @@
       letter-spacing: 0%;
       text-align: center;
       text-decoration: none;
+      background-color: transparent;
+      cursor: pointer;
     }
   }
 
   &_passwordRecovery {
-      margin: 0 0 32px 0;
-      padding: 0;
-      color: rgb(118, 160, 94);
-      font-family: "Inter", Arial, Helvetica, sans-serif;
-      font-size: 13px;
-      font-weight: 600;
-      line-height: 16px;
-      text-decoration: none;
+    margin: 0 0 32px 0;
+    padding: 0;
+    color: rgb(118, 160, 94);
+    font-family: "Inter", Arial, Helvetica, sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 16px;
+    text-decoration: none;
 
-      &:hover {
-        text-decoration: underline;
-      }
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   &__error_mesage {
@@ -76,10 +79,10 @@
     line-height: 16px;
     box-sizing: border-box;
     height: 15px;
-    }
+  }
 }
 
-.containerCloseButton{
+.containerCloseButton {
   position: absolute;
   margin: 0;
   padding: 0;

--- a/src/user/pages/logIn/logIn.tsx
+++ b/src/user/pages/logIn/logIn.tsx
@@ -18,10 +18,12 @@ import loginValidationSchema from "./loginValidationSchema";
 import AuthPageLayout from "../../layout/authPageLayout/AuthPageLayout";
 import { paths } from "../../../app/paths";
 import { Inputs, loginFields } from "../../components/input/constans";
+import { useAuthModal } from "../../providers/AuthModalContext";
 
 const LogIn: FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const { openRegister, closeAuthModal } = useAuthModal();
 
   const {
     register,
@@ -51,7 +53,7 @@ const LogIn: FC = () => {
         dispatch(setUser(userResponse));
         dispatch(setAuthenticated(true));
 
-        navigate(userResponse.role === 'moderator' ? paths.moderation : paths.index);
+        // navigate(userResponse.role === 'moderator' ? paths.moderation : paths.index);
 
         /* if (userResponse.role === "moderator") {
         navigate(paths.moderation);
@@ -61,16 +63,16 @@ const LogIn: FC = () => {
       }
     } catch (err: any) {
       console.error("Ошибка при логине или запросе данных", err);
-      setErrMsg(err.data ? "Неправильная почта или пароль" : "Произошла ошибка");
+      setErrMsg(
+        err.data ? "Неправильная почта или пароль" : "Произошла ошибка"
+      );
     }
   };
 
   return (
     <AuthPageLayout
       title="Вход"
-      onGoBack={() => {
-        navigate(paths.index);
-      }}
+      onGoBack={closeAuthModal}
     >
       <div className={styles.LogIn_containerForm}>
         <UserForm
@@ -107,13 +109,15 @@ const LogIn: FC = () => {
         </UserForm>
 
         <p className={styles.LogIn__error_mesage}>{errMsg}</p>
-        <div className={styles.LogIn_linkRegistr}>
-          <Link
-            to={paths.register}
-            className={styles.LogIn_linkRegistr_linkText}
+        <div className={styles.LogIn_buttonRegistr}>
+          <button
+            onClick={() => {
+              openRegister();
+            }}
+            className={styles.LogIn_buttonRegistr_buttonText}
           >
             Зарегистрироваться
-          </Link>
+          </button>
         </div>
       </div>
     </AuthPageLayout>

--- a/src/user/pages/singin/SignIn.tsx
+++ b/src/user/pages/singin/SignIn.tsx
@@ -17,10 +17,12 @@ import { Inputs, registerFields } from "../../components/input/constans";
 import { paths } from "../../../app/paths";
 import { useDispatch } from "react-redux";
 import { setRegistrated, setUser, User } from "../../../store/slices/authSlice";
+import { useAuthModal } from "../../providers/AuthModalContext";
 
 const Registr: FC = () => {
   const navigate = useNavigate();
-   const dispatch = useDispatch();
+  const dispatch = useDispatch();
+  const { closeAuthModal } = useAuthModal();
 
   const {
     register,
@@ -36,8 +38,7 @@ const Registr: FC = () => {
   });
 
   // отправляем запрос на регистрацию пользователя
-  const [registerUser, { isLoading }] =
-    useRegisterMutation();
+  const [registerUser, { isLoading }] = useRegisterMutation();
 
   useEffect(() => {
     const defaultValues: Inputs = {
@@ -90,7 +91,7 @@ const Registr: FC = () => {
   }, [phoneNumber, setValue]);
 
   return (
-    <AuthPageLayout title="Регистрация" onGoBack={() => navigate(-1)}>
+    <AuthPageLayout title="Регистрация" onGoBack={closeAuthModal}>
       <UserForm
         name="registration"
         onSubmit={handleSubmit(onSubmit)}
@@ -99,8 +100,7 @@ const Registr: FC = () => {
         isLoading={isLoading}
         title="Регистрация"
       >
-
-       {/*  {inputFields.map((field) => ( */}
+        {/*  {inputFields.map((field) => ( */}
         {registerFields.map((field) => (
           <InputForm
             key={field.name}

--- a/src/user/providers/AuthModalContext.tsx
+++ b/src/user/providers/AuthModalContext.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useAppSelector } from "../../store/store";
+
+type AuthType = "login" | "register";
+
+interface AuthModalContext {
+  isOpen: boolean;
+  type: AuthType;
+  openLogin: () => void;
+  openRegister: () => void;
+  closeAuthModal: () => void;
+}
+
+const AuthModalContext = createContext<AuthModalContext | null>(null);
+
+export const useAuthModal = () => {
+  const ctx = useContext(AuthModalContext);
+  if (!ctx) {
+    throw new Error("useAuthModal может использоваться только внутри AuthModalProvider");
+  }
+  return ctx;
+};
+
+export const AuthModalProvider = ({ children }: { children: ReactNode }) => {
+  const userIsAuth = useAppSelector((state) => state.auth.isAuthenticated);
+  const [isOpen, setIsOpen] = useState(false);
+  const [type, setType] = useState<AuthType>("login");
+
+  useEffect(() => {
+    if (isOpen && userIsAuth) {
+      setIsOpen(false);
+    }
+  }, [isOpen, userIsAuth]);
+
+  const openLogin = useCallback(() => {
+    setIsOpen(true);
+    setType("login");
+  }, []);
+
+  const openRegister = useCallback(() => {
+    setIsOpen(true);
+    setType("register");
+  }, []);
+
+  const closeAuthModal = useCallback(() => setIsOpen(false), []);
+
+  const value = useMemo(
+    () => ({
+      isOpen,
+      type,
+      openLogin,
+      openRegister,
+      closeAuthModal,
+    }),
+    [isOpen, type, openLogin, openRegister, closeAuthModal]
+  );
+
+  return (
+    <AuthModalContext.Provider value={value}>
+      {children}
+    </AuthModalContext.Provider>
+  );
+};


### PR DESCRIPTION
#215 
Реализовал единое состояние модального окна авторизации/регистрации на уровне приложения через Context.
Все роуты обёрнуты в AuthModalProvider, благодаря чему модалку можно вызывать из любого места, где требуется авторизация.
После успешной авторизации пользователь не редиректится на другую страницу и остаётся на текущем экране.